### PR TITLE
Add column number to error format

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,8 +6,8 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 if [ "${INPUT_REPORTER}" = x"github-pr-review" ]; then
   markdownlint "${INPUT_MARKDOWNLINT_FLAGS:-.}" |
-    reviewdog -efm="%s:%l %m" -name="markdownlint" -diff="git diff HEAD^" -reporter=github-pr-review -level="${INPUT_LEVEL}" -tee
+    reviewdog -efm="%s:%l:%c %m" -name="markdownlint" -diff="git diff HEAD^" -reporter=github-pr-review -level="${INPUT_LEVEL}" -tee
 else
   markdownlint "${INPUT_MARKDOWNLINT_FLAGS:-.}" |
-    reviewdog -efm="%f:%l %m" -name="markdownlint" -diff="git diff HEAD^" -reporter=github-pr-check -level="${INPUT_LEVEL}" -tee
+    reviewdog -efm="%f:%l:%c %m" -name="markdownlint" -diff="git diff HEAD^" -reporter=github-pr-check -level="${INPUT_LEVEL}" -tee
 fi


### PR DESCRIPTION
Markdownlint-cli outputs a column number now (https://github.com/igorshubovych/markdownlint-cli/commit/a22c5cea6a2450e1ca7f5438bd7fe720baba95db).